### PR TITLE
Added a parser for the ovs rules that we add to gather statistics on pod ports

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/hybrid/proxier.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/hybrid/proxier.go
@@ -1,0 +1,128 @@
+package hybrid
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/proxy/config"
+	"k8s.io/kubernetes/pkg/proxy/iptables"
+	"k8s.io/kubernetes/pkg/proxy/userspace"
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/unidling"
+
+	"github.com/golang/glog"
+)
+
+type Proxier struct {
+	userspaceProxy        *userspace.Proxier
+	userspaceLoadBalancer config.EndpointsConfigHandler
+	iptablesProxy         *iptables.Proxier
+
+	serviceConfig *config.ServiceConfig
+
+	// TODO(directxman12): figure out a good way to avoid duplicating this information
+	// (it's saved in the individual proxies as well)
+	usingUserspace map[types.NamespacedName]bool
+
+	syncPeriod time.Duration
+}
+
+func NewProxier(loadBalancer config.EndpointsConfigHandler, iptablesProxy *iptables.Proxier, userspaceProxy *userspace.Proxier, syncPeriod time.Duration, serviceConfig *config.ServiceConfig) (*Proxier, error) {
+	return &Proxier{
+		userspaceProxy:        userspaceProxy,
+		iptablesProxy:         iptablesProxy,
+		userspaceLoadBalancer: loadBalancer,
+
+		serviceConfig: serviceConfig,
+
+		usingUserspace: nil,
+
+		syncPeriod: syncPeriod,
+	}, nil
+}
+
+func (p *Proxier) OnServiceUpdate(services []api.Service) {
+	forIPTables := make([]api.Service, 0, len(services))
+	forUserspace := []api.Service{}
+
+	for _, service := range services {
+		if !api.IsServiceIPSet(&service) {
+			// Skip service with no ClusterIP set
+			continue
+		}
+		svcName := types.NamespacedName{
+			Namespace: service.Namespace,
+			Name:      service.Name,
+		}
+		if _, ok := p.usingUserspace[svcName]; ok {
+			forUserspace = append(forUserspace, service)
+		} else {
+			forIPTables = append(forIPTables, service)
+		}
+	}
+
+	p.userspaceProxy.OnServiceUpdate(forUserspace)
+	p.iptablesProxy.OnServiceUpdate(forIPTables)
+}
+
+func (p *Proxier) updateUsingUserspace(endpoints []api.Endpoints) {
+	p.usingUserspace = make(map[types.NamespacedName]bool, len(endpoints))
+	for _, endpoint := range endpoints {
+		hasEndpoints := false
+		for _, subset := range endpoint.Subsets {
+			if len(subset.Addresses) > 0 {
+				hasEndpoints = true
+				break
+			}
+		}
+
+		if !hasEndpoints {
+			if _, ok := endpoint.Annotations[unidling.IdledAtAnnotation]; ok {
+				svcName := types.NamespacedName{
+					Namespace: endpoint.Namespace,
+					Name:      endpoint.Name,
+				}
+				p.usingUserspace[svcName] = true
+			}
+		}
+	}
+}
+
+func (p *Proxier) OnEndpointsUpdate(endpoints []api.Endpoints) {
+	p.updateUsingUserspace(endpoints)
+
+	forIPTables := []api.Endpoints{}
+
+	for _, endpoint := range endpoints {
+		svcName := types.NamespacedName{
+			Namespace: endpoint.Namespace,
+			Name:      endpoint.Name,
+		}
+		if _, ok := p.usingUserspace[svcName]; !ok {
+			forIPTables = append(forIPTables, endpoint)
+		}
+	}
+
+	p.userspaceLoadBalancer.OnEndpointsUpdate(endpoints)
+	p.iptablesProxy.OnEndpointsUpdate(forIPTables)
+
+	p.OnServiceUpdate(p.serviceConfig.Config())
+}
+
+// Sync is called to immediately synchronize the proxier state to iptables
+func (p *Proxier) Sync() {
+	p.iptablesProxy.Sync()
+	p.userspaceProxy.Sync()
+}
+
+// SyncLoop runs periodic work.  This is expected to run as a goroutine or as the main loop of the app.  It does not return.
+func (p *Proxier) SyncLoop() {
+	t := time.NewTicker(p.syncPeriod)
+	defer t.Stop()
+	for {
+		<-t.C
+		glog.V(6).Infof("Periodic sync")
+		p.iptablesProxy.Sync()
+		p.userspaceProxy.Sync()
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/userspace/loadbalancer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/userspace/loadbalancer.go
@@ -30,4 +30,5 @@ type LoadBalancer interface {
 	NextEndpoint(service proxy.ServicePortName, srcAddr net.Addr) (string, error)
 	NewService(service proxy.ServicePortName, sessionAffinityType api.ServiceAffinity, stickyMaxAgeMinutes int) error
 	CleanupStaleStickySessions(service proxy.ServicePortName)
+	ServiceHasEndpoints(service proxy.ServicePortName) bool
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/userspace/roundrobin.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/userspace/roundrobin.go
@@ -112,6 +112,17 @@ func isSessionAffinity(affinity *affinityPolicy) bool {
 	return true
 }
 
+// ServiceHasEndpoints checks whether a service entry has endpoints.
+func (lb *LoadBalancerRR) ServiceHasEndpoints(svcPort proxy.ServicePortName) bool {
+	lb.lock.Lock()
+	defer lb.lock.Unlock()
+	if state, exists := lb.services[svcPort]; exists && state != nil && len(state.endpoints) > 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
 // NextEndpoint returns a service endpoint.
 // The service endpoint is chosen using the round-robin algorithm.
 func (lb *LoadBalancerRR) NextEndpoint(svcPort proxy.ServicePortName, srcAddr net.Addr) (string, error) {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/userspace/unidlersocket.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/userspace/unidlersocket.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userspace
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/proxy"
+	"k8s.io/kubernetes/pkg/util/unidling"
+)
+
+type connectionList struct {
+	conns   []heldConn
+	maxSize int
+
+	tickSize       time.Duration
+	timeSinceStart time.Duration
+	timeout        time.Duration
+
+	svcName string
+}
+
+type heldConn struct {
+	net.Conn
+	connectedAt time.Duration
+}
+
+func newConnectionList(maxSize int, tickSize time.Duration, timeout time.Duration, svcName string) *connectionList {
+	return &connectionList{
+		conns:          []heldConn{},
+		maxSize:        maxSize,
+		tickSize:       tickSize,
+		timeSinceStart: 0,
+		timeout:        timeout,
+		svcName:        svcName,
+	}
+}
+
+func (l *connectionList) Add(conn net.Conn) {
+	if len(l.conns) >= l.maxSize {
+		// TODO: look for closed connections
+		glog.Errorf("max connections exceeded while waiting for idled service %s to awaken, dropping oldest", l.svcName)
+		var oldConn net.Conn
+		oldConn, l.conns = l.conns[0], l.conns[1:]
+		oldConn.Close()
+	}
+
+	l.conns = append(l.conns, heldConn{conn, l.timeSinceStart})
+}
+
+func (l *connectionList) Tick() {
+	l.timeSinceStart += l.tickSize
+	l.cleanOldConnections()
+}
+
+func (l *connectionList) cleanOldConnections() {
+	cleanInd := -1
+	for i, conn := range l.conns {
+		if l.timeSinceStart-conn.connectedAt < l.timeout {
+			cleanInd = i
+			break
+		}
+	}
+
+	if cleanInd > 0 {
+		oldConns := l.conns[:cleanInd]
+		l.conns = l.conns[cleanInd:]
+		glog.Errorf("timed out %v connections while waiting for idled service %s to awaken.", len(oldConns), l.svcName)
+
+		for _, conn := range oldConns {
+			conn.Close()
+		}
+	}
+}
+
+func (l *connectionList) GetConns() []net.Conn {
+	conns := make([]net.Conn, len(l.conns))
+	for i, conn := range l.conns {
+		conns[i] = conn.Conn
+	}
+	return conns
+}
+
+func (l *connectionList) Len() int {
+	return len(l.conns)
+}
+
+func (l *connectionList) Clear() {
+	for _, conn := range l.conns {
+		conn.Close()
+	}
+
+	l.conns = []heldConn{}
+}
+
+var (
+	needPodsWaitTimeout = 30 * time.Second
+	needPodsTickLen     = 5 * time.Second
+	maxHeldConnections  = 16
+)
+
+func newUnidlerSocket(protocol api.Protocol, ip net.IP, port int, eventRecorder record.EventRecorder) (proxySocket, error) {
+	host := ""
+	if ip != nil {
+		host = ip.String()
+	}
+
+	switch strings.ToUpper(string(protocol)) {
+	case "TCP":
+		listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+		if err != nil {
+			return nil, err
+		}
+		proxySocket := tcpProxySocket{Listener: listener, port: port}
+		return &tcpUnidlerSocket{tcpProxySocket: proxySocket, eventRecorder: eventRecorder}, nil
+	case "UDP":
+		addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(host, strconv.Itoa(port)))
+		if err != nil {
+			return nil, err
+		}
+		conn, err := net.ListenUDP("udp", addr)
+		if err != nil {
+			return nil, err
+		}
+		proxySocket := udpProxySocket{UDPConn: conn, port: port}
+		return &udpUnidlerSocket{udpProxySocket: proxySocket, eventRecorder: eventRecorder}, nil
+	}
+	return nil, fmt.Errorf("unknown protocol %q", protocol)
+}
+
+// tcpUnidlerSocket implements proxySocket.  Close() is implemented by net.Listener.  When Close() is called,
+// no new connections are allowed but existing connections are left untouched.
+type tcpUnidlerSocket struct {
+	tcpProxySocket
+	eventRecorder record.EventRecorder
+}
+
+func (tcp *tcpUnidlerSocket) waitForEndpoints(ch chan<- interface{}, service proxy.ServicePortName, proxier *Proxier) {
+	defer close(ch)
+	for {
+		if proxier.loadBalancer.ServiceHasEndpoints(service) {
+			// we have endpoints now, so we're finished
+			return
+		}
+
+		// otherwise, wait a bit before checking for endpoints again
+		time.Sleep(endpointDialTimeout[0])
+	}
+}
+
+func (tcp *tcpUnidlerSocket) acceptConns(ch chan<- net.Conn, myInfo *serviceInfo) {
+	defer close(ch)
+
+	// Block until a connection is made.
+	for {
+		inConn, err := tcp.Accept()
+		if err != nil {
+			if isTooManyFDsError(err) {
+				panic("Accept failed: " + err.Error())
+			}
+
+			// TODO: indicate errors here?
+			if isClosedError(err) {
+				return
+			}
+			if !myInfo.isAlive() {
+				// Then the service port was just closed so the accept failure is to be expected.
+				return
+			}
+			glog.Errorf("Accept failed: %v", err)
+			continue
+		}
+
+		ch <- inConn
+	}
+}
+
+func (tcp *tcpUnidlerSocket) ProxyLoop(service proxy.ServicePortName, myInfo *serviceInfo, proxier *Proxier) {
+	if !myInfo.isAlive() {
+		// The service port was closed or replaced.
+		return
+	}
+
+	// accept connections asynchronously
+	inConns := make(chan net.Conn)
+	go tcp.acceptConns(inConns, myInfo)
+
+	endpointsAvail := make(chan interface{})
+	var allConns *connectionList
+
+	svcName := fmt.Sprintf("%s/%s:%s", service.Namespace, service.Name, service.Port)
+
+TOP_LOOP:
+	for {
+		glog.V(4).Infof("unidling TCP proxy start/reset for service %s/%s:%s", service.Namespace, service.Name, service.Port)
+		// collect connections and wait for endpoints to be available
+		sent_need_pods := false
+		timeout_started := false
+		ticker := time.NewTicker(needPodsTickLen)
+		allConns = newConnectionList(maxHeldConnections, needPodsTickLen, needPodsWaitTimeout, svcName)
+
+	WAIT_LOOP:
+		for {
+			select {
+			case inConn, ok := <-inConns:
+				if !ok {
+					// the listen socket has been closed, so we're finished accepting connections
+					break TOP_LOOP
+				}
+
+				if !sent_need_pods && !proxier.loadBalancer.ServiceHasEndpoints(service) {
+					// TODO: There's a constant in origin for this NeedPods
+					// HACK: make the message different to prevent event aggregation
+					glog.V(4).Infof("unidling TCP proxy sent unidle event to wake up service %s/%s:%s", service.Namespace, service.Name, service.Port)
+					tcp.eventRecorder.Eventf(myInfo.ref, unidling.NeedPodsReason, "The service-port %s/%s:%s needs pods (at %v)!", service.Namespace, service.Name, service.Port, time.Now())
+
+					// only send NeedPods once
+					sent_need_pods = true
+					timeout_started = true
+				}
+
+				if allConns.Len() == 0 {
+					if !proxier.loadBalancer.ServiceHasEndpoints(service) {
+						// notify us when endpoints are available
+						go tcp.waitForEndpoints(endpointsAvail, service, proxier)
+					}
+				}
+
+				allConns.Add(inConn)
+				glog.V(4).Infof("unidling TCP proxy has accumulated %v connections while waiting for service %s/%s:%s to unidle", allConns.Len(), service.Namespace, service.Name, service.Port)
+			case <-ticker.C:
+				if !timeout_started {
+					continue WAIT_LOOP
+				}
+				// TODO: timeout each connection (or group of connections) separately
+				// timed out, close all waiting connections and reset the state
+				allConns.Tick()
+			}
+		}
+
+		ticker.Stop()
+	}
+
+	glog.V(4).Infof("unidling TCP proxy waiting for endpoints for service %s/%s:%s to become available with %v accumulated connections", service.Namespace, service.Name, service.Port, allConns.Len())
+	// block until we have endpoints available
+	select {
+	case _, ok := <-endpointsAvail:
+		if ok {
+			close(endpointsAvail)
+			// this shouldn't happen (ok should always be false)
+		}
+	case <-time.NewTimer(needPodsWaitTimeout).C:
+		if allConns.Len() > 0 {
+			glog.Errorf("timed out %v TCP connections while waiting for idled service %s/%s:%s to awaken.", allConns.Len(), service.Namespace, service.Name, service.Port)
+			allConns.Clear()
+		}
+		return
+	}
+	glog.V(4).Infof("unidling TCP proxy got endpoints for service %s/%s:%s, connecting %v accumulated connections", service.Namespace, service.Name, service.Port, allConns.Len())
+
+	for _, inConn := range allConns.GetConns() {
+		glog.V(3).Infof("Accepted TCP connection from %v to %v", inConn.RemoteAddr(), inConn.LocalAddr())
+		outConn, err := tryConnect(service, inConn.(*net.TCPConn).RemoteAddr(), "tcp", proxier)
+		if err != nil {
+			glog.Errorf("Failed to connect to balancer: %v", err)
+			inConn.Close()
+			continue
+		}
+		// Spin up an async copy loop.
+		go proxyTCP(inConn.(*net.TCPConn), outConn.(*net.TCPConn))
+	}
+}
+
+// udpUnidlerSocket implements proxySocket.  Close() is implemented by net.UDPConn.  When Close() is called,
+// no new connections are allowed and existing connections are broken.
+// TODO: We could lame-duck this ourselves, if it becomes important.
+type udpUnidlerSocket struct {
+	udpProxySocket
+	eventRecorder record.EventRecorder
+}
+
+func (udp *udpUnidlerSocket) readFromSock(buffer []byte, myInfo *serviceInfo) bool {
+	if !myInfo.isAlive() {
+		// The service port was closed or replaced.
+		return false
+	}
+
+	// Block until data arrives.
+	// TODO: Accumulate a histogram of n or something, to fine tune the buffer size.
+	_, _, err := udp.ReadFrom(buffer)
+	if err != nil {
+		if e, ok := err.(net.Error); ok {
+			if e.Temporary() {
+				glog.V(1).Infof("ReadFrom had a temporary failure: %v", err)
+				return true
+			}
+		}
+		glog.Errorf("ReadFrom failed, exiting ProxyLoop: %v", err)
+		return false
+	}
+
+	return true
+}
+
+func (udp *udpUnidlerSocket) sendWakeup(service proxy.ServicePortName, myInfo *serviceInfo) (chan<- interface{}, *time.Timer) {
+	stopChan := make(chan interface{})
+	timeoutTimer := time.NewTimer(needPodsWaitTimeout)
+
+	go func(stop <-chan interface{}, timeout <-chan time.Time) {
+		select {
+		case <-stop:
+			return
+		case <-timeout:
+			return
+		case <-time.NewTicker(needPodsWaitTimeout).C:
+			glog.V(4).Infof("unidling proxy sent unidle event to wake up service %s/%s:%s", service.Namespace, service.Name, service.Port)
+			udp.eventRecorder.Eventf(myInfo.ref, unidling.NeedPodsReason, "The service-port %s/%s:%s needs pods (at %v)!", service.Namespace, service.Name, service.Port, time.Now())
+		}
+	}(stopChan, timeoutTimer.C)
+
+	return stopChan, timeoutTimer
+}
+
+func (udp *udpUnidlerSocket) ProxyLoop(service proxy.ServicePortName, myInfo *serviceInfo, proxier *Proxier) {
+	// just drop the packets on the floor until we have endpoints
+	var buffer [4096]byte // 4KiB should be enough for most whole-packets
+
+	glog.V(4).Infof("unidling proxy UDP proxy waiting for data")
+	if !udp.readFromSock(buffer[0:], myInfo) {
+		return
+	}
+
+	stopChan, wakeupTimeoutTimer := udp.sendWakeup(service, myInfo)
+	defer close(stopChan)
+
+	for {
+		if !udp.readFromSock(buffer[0:], myInfo) {
+			break
+		}
+		if active := wakeupTimeoutTimer.Reset(needPodsWaitTimeout); !active {
+			stopChan, wakeupTimeoutTimer = udp.sendWakeup(service, myInfo)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/unidling/constants.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/unidling/constants.go
@@ -1,0 +1,7 @@
+package unidling
+
+const (
+	IdledAtAnnotation = "openshift.io/idled-at"
+	UnidleTargetAnnotation = "openshift.io/unidled"
+	NeedPodsReason = "NeedPods"
+)

--- a/pkg/api/kubegraph/edges.go
+++ b/pkg/api/kubegraph/edges.go
@@ -22,6 +22,8 @@ const (
 	MountableSecretEdgeKind = "MountableSecret"
 	// ReferencedServiceAccountEdgeKind goes from PodSpec to ServiceAccount indicating that Pod is or will be running as the SA.
 	ReferencedServiceAccountEdgeKind = "ReferencedServiceAccount"
+	// HasEndpointsEdgeKind goes from Service to Endpoints, indicating that a service points to those endpoints.
+	HasEndpointsEdgeKind = "HasEndpoints"
 )
 
 // AddExposedPodTemplateSpecEdges ensures that a directed edge exists between a service and all the PodTemplateSpecs
@@ -184,6 +186,17 @@ func AddAllRequestedServiceAccountEdges(g osgraph.Graph) {
 	for _, node := range g.Nodes() {
 		if podSpecNode, ok := node.(*kubegraph.PodSpecNode); ok {
 			AddRequestedServiceAccountEdges(g, podSpecNode)
+		}
+	}
+}
+
+func AddAllHasEndpointsEdges(g osgraph.Graph) {
+	for _, node := range g.Nodes() {
+		if serviceNode, ok := node.(*kubegraph.ServiceNode); ok {
+			endptsName := osgraph.GetUniqueRuntimeObjectNodeName(kubegraph.EndpointsNodeKind, serviceNode.Service)
+			if endptsNode := g.Find(endptsName); endptsNode != nil {
+				g.AddEdge(serviceNode, endptsNode, HasEndpointsEdgeKind)
+			}
 		}
 	}
 }

--- a/pkg/api/kubegraph/nodes/nodes.go
+++ b/pkg/api/kubegraph/nodes/nodes.go
@@ -42,6 +42,16 @@ func EnsureServiceNode(g osgraph.MutableUniqueGraph, svc *kapi.Service) *Service
 	).(*ServiceNode)
 }
 
+// EnsureEndpointsNode adds the provided endpoints to the graph if it does not already exist.
+func EnsureEndpointsNode(g osgraph.MutableUniqueGraph, endpts *kapi.Endpoints) *EndpointsNode {
+	return osgraph.EnsureUnique(g,
+		EndpointsNodeName(endpts),
+		func(node osgraph.Node) graph.Node {
+			return &EndpointsNode{node, endpts, true}
+		},
+	).(*EndpointsNode)
+}
+
 // FindOrCreateSyntheticServiceNode returns the existing service node or creates a synthetic node in its place
 func FindOrCreateSyntheticServiceNode(g osgraph.MutableUniqueGraph, svc *kapi.Service) *ServiceNode {
 	return osgraph.EnsureUnique(g,

--- a/pkg/api/kubegraph/nodes/types.go
+++ b/pkg/api/kubegraph/nodes/types.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	ServiceNodeKind                   = reflect.TypeOf(kapi.Service{}).Name()
+	EndpointsNodeKind                 = reflect.TypeOf(kapi.Endpoints{}).Name()
 	PodNodeKind                       = reflect.TypeOf(kapi.Pod{}).Name()
 	PodSpecNodeKind                   = reflect.TypeOf(kapi.PodSpec{}).Name()
 	PodTemplateSpecNodeKind           = reflect.TypeOf(kapi.PodTemplateSpec{}).Name()
@@ -48,6 +49,37 @@ func (*ServiceNode) Kind() string {
 }
 
 func (n ServiceNode) Found() bool {
+	return n.IsFound
+}
+
+func EndpointsNodeName(o *kapi.Endpoints) osgraph.UniqueName {
+	return osgraph.GetUniqueRuntimeObjectNodeName(EndpointsNodeKind, o)
+}
+
+type EndpointsNode struct {
+	osgraph.Node
+	*kapi.Endpoints
+
+	IsFound bool
+}
+
+func (n EndpointsNode) Object() interface{} {
+	return n.Endpoints
+}
+
+func (n EndpointsNode) String() string {
+	return string(EndpointsNodeName(n.Endpoints))
+}
+
+func (n EndpointsNode) ResourceString() string {
+	return "svc/" + n.Name
+}
+
+func (*EndpointsNode) Kind() string {
+	return EndpointsNodeKind
+}
+
+func (n EndpointsNode) Found() bool {
 	return n.IsFound
 }
 

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -75,6 +75,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdNewApplication(fullName, f, out),
 				cmd.NewCmdStatus(cmd.StatusRecommendedName, fullName+" "+cmd.StatusRecommendedName, f, out),
 				cmd.NewCmdProject(fullName+" project", f, out),
+				cmd.NewCmdIdle(fullName, f, out),
 			},
 		},
 		{

--- a/pkg/cmd/cli/cmd/idle.go
+++ b/pkg/cmd/cli/cmd/idle.go
@@ -1,0 +1,417 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	"github.com/openshift/origin/pkg/api/graph/graphview"
+	kubeedges "github.com/openshift/origin/pkg/api/kubegraph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/cli/describe"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/strategicpatch"
+	"k8s.io/kubernetes/pkg/util/unidling"
+)
+
+const (
+	idleLong = `
+Associate objects in the current project with each other.
+
+This command allows you to associate different objects in the current project with each other
+(like the status command).  Currently, it associates services with RCs and DCs.  It will
+only list services, DCs, and RCs that are associated -- services that only point to pods,
+as well as RCs and DCs with no services, will not be listed.`
+
+	idleExample = `  # Associate services with RCs and DCs
+  $ %[1]s idle`
+)
+
+// NewCmdStatus implements the OpenShift cli status command
+func NewCmdIdle(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	var inputFile string
+	dryRun := false
+	loadByService := false
+
+	cmd := &cobra.Command{
+		Use:     "idle -f FILENAME",
+		Short:   "Idle scalable objects",
+		Long:    idleLong,
+		Example: fmt.Sprintf(idleExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(RunIdle(f, out, cmd, inputFile, loadByService, dryRun))
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "If true, only print the annotations that would be written, without annotating or idling the relevant objects")
+	cmd.Flags().StringVarP(&inputFile, "filename", "f", "", "file containing list of scalable objects to idle")
+	cmd.Flags().BoolVar(&loadByService, "by-service", loadByService, "If true, the input list will be treated as a list of services whose associated RCs and DCs should be idle, instead of being a list of RCs and DCs to idle")
+	cmd.MarkFlagRequired("filename")
+
+	return cmd
+}
+
+func getPodTemplateSpecNode(g osgraph.Graph, node osgraph.Node) *kubegraph.PodTemplateSpecNode {
+	rcSpecNodes := g.SuccessorNodesByNodeAndEdgeKind(node, kubegraph.ReplicationControllerSpecNodeKind, osgraph.ContainsEdgeKind)
+	if len(rcSpecNodes) != 1 {
+		panic(fmt.Sprintf("expected ReplicationControllerNode/DeploymentConfigNode %s to have a single ReplicationControllerSpecNode contained within it", g.GraphDescriber.Name(node)))
+	}
+
+	rcPodTemplateSpecNodes := g.SuccessorNodesByNodeAndEdgeKind(rcSpecNodes[0], kubegraph.PodTemplateSpecNodeKind, osgraph.ContainsEdgeKind)
+
+	if len(rcPodTemplateSpecNodes) == 0 {
+		return nil
+	} else if len(rcPodTemplateSpecNodes) > 1 {
+		panic(fmt.Sprintf("expected ReplicationControllerSpecNode %s to have no more than one PodTemplateSpecNode contained within it", g.GraphDescriber.Name(rcSpecNodes[0])))
+	}
+
+	return rcPodTemplateSpecNodes[0].(*kubegraph.PodTemplateSpecNode)
+}
+
+func getEndpointsNode(g osgraph.Graph, node osgraph.Node) *kubegraph.EndpointsNode {
+	endpointsNodes := g.SuccessorNodesByNodeAndEdgeKind(node, kubegraph.EndpointsNodeKind, kubeedges.HasEndpointsEdgeKind)
+	if len(endpointsNodes) != 1 {
+		panic(fmt.Sprintf("expected ServiceNode %s to have a single EndpointsNode corresponding to it", g.GraphDescriber.Name(node)))
+	}
+
+	return endpointsNodes[0].(*kubegraph.EndpointsNode)
+}
+
+func scanIdlableResourcesFromFile(filename string) (map[string]bool, error) {
+	targetResources := make(map[string]bool)
+	var targetsInput io.Reader
+	if filename == "-" {
+		targetsInput = os.Stdin
+	} else if filename == "" {
+		return nil, fmt.Errorf("you must specify an list of resources to idle")
+	} else {
+		inputFile, err := os.Open(filename)
+		if err != nil {
+			return nil, err
+		}
+		defer inputFile.Close()
+		targetsInput = inputFile
+	}
+
+	targetsScanner := bufio.NewScanner(targetsInput)
+	for targetsScanner.Scan() {
+		targetResources[targetsScanner.Text()] = true
+	}
+	if err := targetsScanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return targetResources, nil
+}
+
+type idleUpdateInfo struct {
+	obj         runtime.Object
+	annotations []string
+}
+
+func calculateIdlableAnnotationsByScalable(f *clientcmd.Factory, cmd *cobra.Command, namespace, filename string) (map[string]idleUpdateInfo, map[string]idleUpdateInfo, error) {
+	// load the target scalables (they should be in the form of "fullresourcetype/resourcename")
+	actualScalables, err := scanIdlableResourcesFromFile(filename)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// use a visitor to resolve the correct names (and check the validity of the resolved resources)
+	client, kclient, err := f.Clients()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// set up our clients for creating the graph
+	config, err := f.OpenShiftClientConfig.ClientConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	describer := &describe.ProjectStatusDescriber{K: kclient, C: client, Server: config.Host}
+	// we only need services, rcs, and dcs, not the rest of the objects in the graph
+	g, _, err := describer.MakeGraph(namespace, "services", "endpoints", "replicationcontrollers", "deploymentconfigs")
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	byService := make(map[string]idleUpdateInfo)
+	byScalable := make(map[string]idleUpdateInfo)
+
+	// calculate associated services for all RC and DC nodes
+	for _, uncastRCNode := range g.NodesByKind(kubegraph.ReplicationControllerNodeKind) {
+		rcNode := uncastRCNode.(*kubegraph.ReplicationControllerNode)
+		rcRes := rcNode.Kind() + "/" + rcNode.Name
+
+		if _, ok := actualScalables[rcRes]; !ok {
+			continue
+		}
+
+		rcPodTemplateSpecNode := getPodTemplateSpecNode(g, rcNode.Node)
+		if rcPodTemplateSpecNode == nil {
+			continue
+		}
+		for _, uncastServiceNode := range g.SuccessorNodesByEdgeKind(rcPodTemplateSpecNode, kubeedges.ExposedThroughServiceEdgeKind) {
+			serviceNode := uncastServiceNode.(*kubegraph.ServiceNode)
+			endpointsNode := getEndpointsNode(g, serviceNode.Node)
+
+			serviceInfo := byService[endpointsNode.Name]
+			serviceInfo.annotations = append(serviceInfo.annotations, rcRes)
+			endpointsNode.Endpoints.Kind = endpointsNode.Kind()
+			serviceInfo.obj = endpointsNode.Endpoints
+			byService[endpointsNode.Name] = serviceInfo
+
+			scalableInfo := byScalable[rcRes]
+			scalableInfo.annotations = append(scalableInfo.annotations, endpointsNode.Name)
+			rcNode.ReplicationController.Kind = rcNode.Kind()
+			scalableInfo.obj = rcNode.ReplicationController
+			byScalable[rcRes] = scalableInfo
+		}
+	}
+
+	for _, uncastDCNode := range g.NodesByKind(deploygraph.DeploymentConfigNodeKind) {
+		dcNode := uncastDCNode.(*deploygraph.DeploymentConfigNode)
+		dcRes := dcNode.Kind() + "/" + dcNode.Name
+
+		if _, ok := actualScalables[dcRes]; !ok {
+			continue
+		}
+
+		dcPodTemplateSpecNode := getPodTemplateSpecNode(g, dcNode.Node)
+		if dcPodTemplateSpecNode == nil {
+			continue
+		}
+		for _, uncastServiceNode := range g.SuccessorNodesByEdgeKind(dcPodTemplateSpecNode, kubeedges.ExposedThroughServiceEdgeKind) {
+			serviceNode := uncastServiceNode.(*kubegraph.ServiceNode)
+			endpointsNode := getEndpointsNode(g, serviceNode.Node)
+
+			serviceInfo := byService[endpointsNode.Name]
+			serviceInfo.annotations = append(serviceInfo.annotations, dcRes)
+			endpointsNode.Endpoints.Kind = endpointsNode.Kind()
+			serviceInfo.obj = endpointsNode.Endpoints
+			byService[endpointsNode.Name] = serviceInfo
+
+			scalableInfo := byScalable[dcRes]
+			scalableInfo.annotations = append(scalableInfo.annotations, endpointsNode.Name)
+			dcNode.DeploymentConfig.Kind = dcNode.Kind()
+			scalableInfo.obj = dcNode.DeploymentConfig
+			byScalable[dcRes] = scalableInfo
+		}
+	}
+
+	return byService, byScalable, nil
+}
+
+func calculateIdlableAnnotationsByService(f *clientcmd.Factory, cmd *cobra.Command, namespace, filename string) (map[string][]string, map[string][]string, error) {
+	// load our set of scalables
+	targetServices, err := scanIdlableResourcesFromFile(filename)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, kclient, err := f.Clients()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// set up our clients for creating the graph
+	config, err := f.OpenShiftClientConfig.ClientConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	describer := &describe.ProjectStatusDescriber{K: kclient, C: client, Server: config.Host}
+	g, _, err := describer.MakeGraph(namespace)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	byService := make(map[string][]string)
+	byScalable := make(map[string][]string)
+
+	// get all services, make associations
+	// NB: ResourceString uses the abbreviated form, we want the expanded form
+	services, _ := graphview.AllServiceGroups(g, graphview.IntSet{})
+	for _, serviceGroup := range services {
+		if !serviceGroup.Service.Found() {
+			continue
+		}
+
+		if _, ok := targetServices[serviceGroup.Service.Name]; !ok {
+			continue
+		}
+
+		coveredRCs := graphview.IntSet{}
+		svcRes := serviceGroup.Service.Name
+
+		for _, dc := range serviceGroup.DeploymentConfigPipelines {
+			dcRes := dc.Deployment.Kind() + "/" + dc.Deployment.Name
+			byService[svcRes] = append(byService[svcRes], dcRes)
+			byScalable[dcRes] = append(byScalable[dcRes], svcRes)
+
+			// don't also add RCs covered by DCs
+			for _, rc := range dc.InactiveDeployments {
+				coveredRCs.Insert(rc.ID())
+			}
+			coveredRCs.Insert(dc.ActiveDeployment.ID())
+		}
+
+		for _, rc := range serviceGroup.FulfillingRCs {
+			if coveredRCs.Has(rc.ID()) {
+				continue
+			}
+			rcRes := rc.Kind() + "/" + rc.Name
+			byService[svcRes] = append(byService[svcRes], rc.ResourceString())
+			byScalable[rcRes] = append(byScalable[rcRes], svcRes)
+		}
+	}
+
+	return byService, byScalable, nil
+}
+
+func setIdleAnnotations(obj runtime.Object, key string, vals []string) error {
+	meta, err := api.ObjectMetaFor(obj)
+	if err != nil {
+		return err
+	}
+
+	if meta.Annotations == nil {
+		meta.Annotations = make(map[string]string)
+	}
+
+	// TODO(directxman12): preserve values across calls?
+	meta.Annotations[key] = strings.Join(vals, ",")
+	meta.Annotations[unidling.IdledAtAnnotation] = time.Now().UTC().Format(time.RFC3339)
+
+	return nil
+}
+
+func patchObj(obj runtime.Object, metadata meta.Interface, oldData []byte, mapping *meta.RESTMapping, f *clientcmd.Factory) (runtime.Object, error) {
+	newData, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := f.RESTClient(mapping)
+	if err != nil {
+		return nil, err
+	}
+	helper := resource.NewHelper(client, mapping)
+
+	return helper.Patch(metadata.Namespace(), metadata.Name(), api.StrategicMergePatchType, patchBytes)
+}
+
+func RunIdle(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, filename string, loadByService, dryRun bool) error {
+	namespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	var byService map[string]idleUpdateInfo
+	var byScalable map[string]idleUpdateInfo
+
+	mapper, _ := f.Object()
+	if loadByService {
+		//byService, byScalable, err = calculateIdlableAnnotationsByService(f, cmd, namespace, filename)
+	} else {
+		byService, byScalable, err = calculateIdlableAnnotationsByScalable(f, cmd, namespace, filename)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	oclient, kclient, err := f.Clients()
+	if err != nil {
+		return err
+	}
+	delegScaleNamespacer := osclient.NewDelegatingScaleNamespacer(oclient, kclient)
+
+	// load all the resources
+	for serviceName, info := range byService {
+		if !dryRun {
+			metadata, err := meta.Accessor(info.obj)
+			if err != nil {
+				// TODO: return list of errors at the end
+				return err
+			}
+			typeInfo, err := meta.TypeAccessor(info.obj)
+			if err != nil {
+				return err
+			}
+			oldData, err := json.Marshal(info.obj)
+			if err != nil {
+				return err
+			}
+
+			mapping, err := mapper.RESTMapping(typeInfo.Kind(), typeInfo.APIVersion())
+			if err != nil {
+				return err
+			}
+
+			if err := setIdleAnnotations(info.obj, unidling.UnidleTargetAnnotation, info.annotations); err != nil {
+				return err
+			}
+			if _, err := patchObj(info.obj, metadata, oldData, mapping, f); err != nil {
+				return err
+			}
+		}
+
+		fmt.Fprintf(out, "Annotated service/%s with %v\n", serviceName, info.annotations)
+	}
+
+	for fullName, info := range byScalable {
+		if !dryRun {
+			metadata, err := meta.Accessor(info.obj)
+			if err != nil {
+				// TODO: return list of errors at the end
+				return err
+			}
+			typeInfo, err := meta.TypeAccessor(info.obj)
+			if err != nil {
+				return err
+			}
+			mapping, err := mapper.RESTMapping(typeInfo.Kind(), typeInfo.APIVersion())
+			if err != nil {
+				return err
+			}
+
+			scale, err := delegScaleNamespacer.Scales(namespace).Get(mapping.Kind, metadata.Name())
+			if err != nil {
+				return err
+			}
+
+			scale.Spec.Replicas = 0
+
+			if _, err := delegScaleNamespacer.Scales(namespace).Update(mapping.Kind, scale); err != nil {
+				// TODO: use retry logic from scaler package?
+				return err
+			}
+		}
+
+		fmt.Fprintf(out, "Annotated %s with %v, scaled to 0\n", fullName, info.annotations)
+	}
+
+	return nil
+}

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -54,23 +54,45 @@ type ProjectStatusDescriber struct {
 	Suggest bool
 }
 
-func (d *ProjectStatusDescriber) MakeGraph(namespace string) (osgraph.Graph, sets.String, error) {
+func (d *ProjectStatusDescriber) MakePartialGraph(namespace string, resourceTypes ...string) {
+}
+
+func (d *ProjectStatusDescriber) MakeGraph(namespace string, resourceTypes ...string) (osgraph.Graph, sets.String, error) {
 	g := osgraph.New()
 
-	loaders := []GraphLoader{
-		&serviceLoader{namespace: namespace, lister: d.K},
-		&serviceAccountLoader{namespace: namespace, lister: d.K},
-		&secretLoader{namespace: namespace, lister: d.K},
-		&rcLoader{namespace: namespace, lister: d.K},
-		&podLoader{namespace: namespace, lister: d.K},
+	allLoaders := map[string]GraphLoader{
+		"services":               &serviceLoader{namespace: namespace, lister: d.K},
+		"endpoints":              &endpointsLoader{namespace: namespace, lister: d.K},
+		"serviceaccounts":        &serviceAccountLoader{namespace: namespace, lister: d.K},
+		"secrets":                &secretLoader{namespace: namespace, lister: d.K},
+		"replicationcontrollers": &rcLoader{namespace: namespace, lister: d.K},
+		"pods": &podLoader{namespace: namespace, lister: d.K},
 		// TODO check swagger for feature enablement and selectively add bcLoader and buildLoader
 		// then remove errors.TolerateNotFoundError method.
-		&bcLoader{namespace: namespace, lister: d.C},
-		&buildLoader{namespace: namespace, lister: d.C},
-		&isLoader{namespace: namespace, lister: d.C},
-		&dcLoader{namespace: namespace, lister: d.C},
-		&routeLoader{namespace: namespace, lister: d.C},
+		"buildconfigs":      &bcLoader{namespace: namespace, lister: d.C},
+		"builds":            &buildLoader{namespace: namespace, lister: d.C},
+		"imagestreams":      &isLoader{namespace: namespace, lister: d.C},
+		"deploymentconfigs": &dcLoader{namespace: namespace, lister: d.C},
+		"routes":            &routeLoader{namespace: namespace, lister: d.C},
 	}
+
+	var loaders []GraphLoader
+
+	if len(resourceTypes) == 0 {
+		loaders = make([]GraphLoader, 0, len(allLoaders))
+		for _, loader := range allLoaders {
+			loaders = append(loaders, loader)
+		}
+	} else {
+		loaders = make([]GraphLoader, len(resourceTypes))
+		for i, res := range resourceTypes {
+			// TODO: gracefully return error here?
+			if loader, ok := allLoaders[res]; ok {
+				loaders[i] = loader
+			}
+		}
+	}
+
 	loadingFuncs := []func() error{}
 	for _, loader := range loaders {
 		loadingFuncs = append(loadingFuncs, loader.Load)
@@ -105,6 +127,7 @@ func (d *ProjectStatusDescriber) MakeGraph(namespace string) (osgraph.Graph, set
 	kubeedges.AddAllRequestedServiceAccountEdges(g)
 	kubeedges.AddAllMountableSecretEdges(g)
 	kubeedges.AddAllMountedSecretEdges(g)
+	kubeedges.AddAllHasEndpointsEdges(g)
 	buildedges.AddAllInputOutputEdges(g)
 	buildedges.AddAllBuildEdges(g)
 	deployedges.AddAllTriggerEdges(g)
@@ -831,6 +854,30 @@ func (l *serviceLoader) Load() error {
 func (l *serviceLoader) AddToGraph(g osgraph.Graph) error {
 	for i := range l.items {
 		kubegraph.EnsureServiceNode(g, &l.items[i])
+	}
+
+	return nil
+}
+
+type endpointsLoader struct {
+	namespace string
+	lister    kclient.EndpointsNamespacer
+	items     []kapi.Endpoints
+}
+
+func (l *endpointsLoader) Load() error {
+	list, err := l.lister.Endpoints(l.namespace).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	l.items = list.Items
+	return nil
+}
+
+func (l *endpointsLoader) AddToGraph(g osgraph.Graph) error {
+	for i := range l.items {
+		kubegraph.EnsureEndpointsNode(g, &l.items[i])
 	}
 
 	return nil

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -142,7 +142,7 @@ func (o *RouterSelection) Complete() error {
 
 // NewFactory initializes a factory that will watch the requested routes
 func (o *RouterSelection) NewFactory(oc oclient.Interface, kc kclient.Interface) *controllerfactory.RouterControllerFactory {
-	factory := controllerfactory.NewDefaultRouterControllerFactory(oc, kc)
+	factory := controllerfactory.NewDefaultRouterControllerFactory(oc, kc, kc)
 	factory.Labels = o.Labels
 	factory.Fields = o.Fields
 	factory.Namespace = o.Namespace

--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -222,7 +222,7 @@ func (c *NodeConfig) RunProxy() {
 		return
 	}
 
-	userspaceProxy, err := uproxy.NewProxier(loadBalancer, ip, iptables, util.PortRange{}, syncPeriod)
+	userspaceProxy, err := uproxy.NewUnidlerProxier(loadBalancer, ip, iptables, util.PortRange{}, syncPeriod, recorder)
 	if err != nil {
 		glog.Warningf("WARNING: Could not initialize Kubernetes Proxy. You must run this process as root to use the service proxy: %v", err)
 		return

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -523,6 +523,12 @@ func (c *MasterConfig) OriginNamespaceControllerClients() (*osclient.Client, *kc
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
+// UnidlingControllerClients returns the unidling controller clients
+func (c *MasterConfig) UnidlingControllerClients() (*osclient.Client, *kclient.Client) {
+	// TODO(directxman12): make this use service account clients
+	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
+}
+
 // NewEtcdHelper returns an EtcdHelper for the provided storage version.
 func NewEtcdStorage(client *etcdclient.Client, version, prefix string) (oshelper storage.Interface, err error) {
 	interfaces, err := latest.InterfacesFor(version)

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -20,6 +20,7 @@ import (
 	buildclient "github.com/openshift/origin/pkg/build/client"
 	buildcontrollerfactory "github.com/openshift/origin/pkg/build/controller/factory"
 	buildstrategy "github.com/openshift/origin/pkg/build/controller/strategy"
+	osclient "github.com/openshift/origin/pkg/client"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	configchangecontroller "github.com/openshift/origin/pkg/deploy/controller/configchange"
@@ -34,6 +35,7 @@ import (
 	"github.com/openshift/origin/pkg/security/mcs"
 	"github.com/openshift/origin/pkg/security/uid"
 	"github.com/openshift/origin/pkg/security/uidallocator"
+	unidlingcontroller "github.com/openshift/origin/pkg/unidling"
 
 	"github.com/openshift/openshift-sdn/plugins/osdn/factory"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -405,4 +407,14 @@ func (c *MasterConfig) RunSecurityAllocationController() {
 // RunGroupCache starts the group cache
 func (c *MasterConfig) RunGroupCache() {
 	c.GroupCache.Run()
+}
+
+// RunUnidlingController starts the unidling controller
+func (c *MasterConfig) RunUnidlingController() {
+	oc, kc := c.UnidlingControllerClients()
+	resyncPeriod := 2 * time.Minute
+	delegScaleNamespacer := osclient.NewDelegatingScaleNamespacer(oc, kc)
+	cont := unidlingcontroller.NewUnidlingController(delegScaleNamespacer, kc, kc, resyncPeriod)
+
+	cont.Run(util.NeverStop)
 }

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -579,6 +579,8 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 	oc.RunOriginNamespaceController()
 	oc.RunSDNController()
 
+	oc.RunUnidlingController()
+
 	glog.Infof("Started Origin Controllers")
 
 	return nil

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -59,11 +59,11 @@ func (p *UniqueHost) HostLen() int {
 }
 
 // HandleEndpoints processes watch events on the Endpoints resource.
-func (p *UniqueHost) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
+func (p *UniqueHost) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints, service *kapi.Service) error {
 	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(endpoints.Namespace) {
 		return nil
 	}
-	return p.plugin.HandleEndpoints(eventType, endpoints)
+	return p.plugin.HandleEndpoints(eventType, endpoints, service)
 }
 
 // HandleRoute processes watch events on the Route resource.

--- a/pkg/router/interfaces.go
+++ b/pkg/router/interfaces.go
@@ -12,7 +12,7 @@ import (
 // for the Routes and Endpoints resources to.
 type Plugin interface {
 	HandleRoute(watch.EventType, *routeapi.Route) error
-	HandleEndpoints(watch.EventType, *kapi.Endpoints) error
+	HandleEndpoints(watch.EventType, *kapi.Endpoints, *kapi.Service) error
 	// If sent, filter the list of accepted routes and endpoints to this set
 	HandleNamespaces(namespaces sets.String) error
 }

--- a/pkg/unidling/controller.go
+++ b/pkg/unidling/controller.go
@@ -1,0 +1,183 @@
+package unidling
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/client/cache"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/unidling"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/golang/glog"
+)
+
+type UnidlingController struct {
+	controller          *framework.Controller
+	scaleNamespacer     kclient.ScaleNamespacer
+	endpointsNamespacer kclient.EndpointsNamespacer
+}
+
+func NewUnidlingController(scaleNS kclient.ScaleNamespacer, endptsNS kclient.EndpointsNamespacer, evtNS kclient.EventNamespacer, resyncPeriod time.Duration) *UnidlingController {
+	fieldSet := fields.Set{}
+	fieldSet["reason"] = unidling.NeedPodsReason
+	fieldSelector := fieldSet.AsSelector()
+
+	unidlingController := &UnidlingController{
+		scaleNamespacer:     scaleNS,
+		endpointsNamespacer: endptsNS,
+	}
+
+	_, controller := framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return evtNS.Events(api.NamespaceAll).List(labels.Everything(), fieldSelector)
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return evtNS.Events(api.NamespaceAll).Watch(labels.Everything(), fieldSelector, resourceVersion)
+			},
+		},
+		&api.Event{},
+		resyncPeriod,
+		framework.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				event := obj.(*api.Event)
+
+				if event.Reason != unidling.NeedPodsReason {
+					glog.Errorf("UnidlingController was asked to handle a non-NeedPods event")
+					return
+				}
+
+				if err := unidlingController.handleEvent(event); err != nil {
+					targetNamespace := event.InvolvedObject.Namespace
+					targetServiceName := event.InvolvedObject.Name
+					glog.Errorf("Unable to unidle %s/%s: %v", targetNamespace, targetServiceName, err)
+				}
+			},
+		},
+	)
+
+	unidlingController.controller = controller
+
+	return unidlingController
+}
+
+func (c *UnidlingController) Run(stopCh <-chan struct{}) {
+	defer util.HandleCrash()
+	go c.controller.Run(stopCh)
+}
+
+// TODO: does this need to send error events?
+func (c *UnidlingController) handleEvent(event *api.Event) error {
+	targetNamespace := event.InvolvedObject.Namespace
+	targetServiceName := event.InvolvedObject.Name
+
+	targetEndpoints, err := c.endpointsNamespacer.Endpoints(targetNamespace).Get(targetServiceName)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve service: %v", err)
+	}
+
+	// check when we were idled to prevent historical unidling
+	idledTimeRaw, wasIdled := targetEndpoints.Annotations[unidling.IdledAtAnnotation]
+	if !wasIdled {
+		glog.V(5).Infof("UnidlingController received a NeedPods event for a service that was not idled, ignoring")
+		return nil
+	}
+
+	idledTime, err := time.Parse(time.RFC3339, idledTimeRaw)
+	if err != nil {
+		return fmt.Errorf("unable to check idled-at time: %v", err)
+	}
+	if event.LastTimestamp.Time.Before(idledTime) {
+		glog.V(5).Infof("UnidlingController received an out-of-date NeedPods event, ignoring")
+		return nil
+	}
+
+	var targetScalablesRaw []string
+	if targetScalablesStr, hasTargetScalables := targetEndpoints.Annotations[unidling.UnidleTargetAnnotation]; hasTargetScalables {
+		targetScalablesRaw = strings.Split(targetScalablesStr, ",")
+	} else {
+		glog.V(4).Infof("Service %s/%s had no scalables to unidle", targetNamespace, targetServiceName)
+		targetScalablesRaw = []string{}
+	}
+
+	targetScalablesSet := make(map[string]bool, len(targetScalablesRaw))
+	for _, v := range targetScalablesRaw {
+		targetScalablesSet[v] = true
+	}
+
+	scales := c.scaleNamespacer.Scales(targetNamespace)
+	for _, scalableRef := range targetScalablesRaw {
+		kind, name, err := extractScalableInfo(scalableRef)
+		if err != nil {
+			glog.Errorf("Invalid scalable reference while unidling service %s/%s: %v", targetNamespace, targetServiceName, err)
+			delete(targetScalablesSet, scalableRef)
+			continue
+		}
+
+		scale, err := scales.Get(kind, name)
+		if err != nil {
+			glog.Errorf("Unable get scale for %s while unidling service %s/%s: %v", scalableRef, targetNamespace, targetServiceName, err)
+			if errors.IsNotFound(err) {
+				delete(targetScalablesSet, scalableRef)
+			}
+			continue
+		}
+
+		if scale.Spec.Replicas > 0 {
+			glog.Errorf("%s is not idle, skipping while unidling service %s/%s", scalableRef, targetNamespace, targetServiceName)
+			continue
+		}
+
+		scale.Spec.Replicas = 1
+
+		if _, err := scales.Update(kind, scale); err != nil {
+			glog.Errorf("Unable to scale up %s while unidling service %s/%s: %v", scalableRef, err)
+			if errors.IsNotFound(err) {
+				delete(targetScalablesSet, scalableRef)
+			}
+			continue
+		} else {
+			glog.V(4).Infof("Scaled up %s while unidling service %s/%s", scalableRef, targetNamespace, targetServiceName)
+		}
+
+		delete(targetScalablesSet, scalableRef)
+	}
+
+	newAnnotationList := make([]string, 0, len(targetScalablesSet))
+	for k := range targetScalablesSet {
+		newAnnotationList = append(newAnnotationList, k)
+	}
+
+	// TODO(directxman12): do we need to re-fetch the service to avoid conflicts while updating?
+	if len(newAnnotationList) == 0 {
+		delete(targetEndpoints.Annotations, unidling.UnidleTargetAnnotation)
+		delete(targetEndpoints.Annotations, unidling.IdledAtAnnotation)
+	} else {
+		targetEndpoints.Annotations[unidling.UnidleTargetAnnotation] = strings.Join(newAnnotationList, ",")
+	}
+
+	if _, err := c.endpointsNamespacer.Endpoints(targetNamespace).Update(targetEndpoints); err != nil {
+		return fmt.Errorf("unable to update/remove idle annotations from %s/%s: %v")
+	}
+
+	return nil
+}
+
+func extractScalableInfo(scalableRef string) (string, string, error) {
+	// TODO: this should probably be something more concrete than "resource/name" (or here, for convenience, Kind/name)
+	refParts := strings.Split(scalableRef, "/")
+	if len(refParts) != 2 {
+		return "", "", fmt.Errorf("%s was not in the form kind/name", scalableRef)
+	}
+
+	return refParts[0], refParts[1], nil
+}

--- a/pkg/unidling/ovsparser/parse.go
+++ b/pkg/unidling/ovsparser/parse.go
@@ -1,0 +1,88 @@
+package ovsparser
+
+import (
+	"log"
+	"strconv"
+	"strings"
+)
+
+type portStats struct {
+	packets uint64
+	bytes   uint64
+}
+
+type IPPortStats map[string]map[int]portStats
+
+func Parse(raw []byte) (IPPortStats, error) {
+
+	ipPortData := make(IPPortStats)
+
+	// Ignore the header line
+	lines := strings.Split(string(raw), "\n")[1:]
+
+	for _, line := range lines {
+		// Get rid of actions= ... at the end
+		junk := strings.Split(line, " actions=")
+		line = junk[0]
+
+		// See if the line is blank after our cleaning
+		if line == "" {
+			continue
+		}
+
+		// Lose the leading spaces
+		line := strings.Trim(line, " ")
+
+		data := make(map[string]string)
+
+		pairs := strings.Split(line, ",")
+		for _, pair := range pairs {
+			pair = strings.Trim(pair, " ")
+			kv := strings.SplitN(pair, "=", 2)
+			if len(kv) == 2 {
+				data[kv[0]] = kv[1]
+			} else {
+				data[kv[0]] = ""
+			}
+		}
+
+		ip, found := data["nw_dst"]
+		if !found {
+			// If there's no IP, ignore it and move on to the next line
+			continue
+		}
+
+		portStr, found := data["tp_dst"]
+		if !found {
+			portStr = "0"
+		}
+
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			log.Printf("Bad port %s\n\n%#v", line, data)
+			return nil, err
+		}
+		packets, err := strconv.ParseUint(data["n_packets"], 10, 64)
+		if err != nil {
+			log.Printf("Bad packets: %s\n\n%#v", line, data)
+			return nil, err
+		}
+		bytes, err := strconv.ParseUint(data["n_bytes"], 10, 64)
+		if err != nil {
+			log.Printf("Bad bytes: %s\n\n%#v", line, data)
+			return nil, err
+		}
+
+		_, found = ipPortData[ip]
+		if !found {
+			ipPortData[ip] = make(map[int]portStats)
+		}
+
+		ipPortData[ip][port] = portStats{
+			packets: packets,
+			bytes:   bytes,
+		}
+	}
+
+	return ipPortData, nil
+}

--- a/plugins/router/f5/plugin.go
+++ b/plugins/router/f5/plugin.go
@@ -227,7 +227,7 @@ func poolName(endpointsNamespace, endpointsName string) string {
 // HandleEndpoints processes watch events on the Endpoints resource and
 // creates and deletes pools and pool members in response.
 func (p *F5Plugin) HandleEndpoints(eventType watch.EventType,
-	endpoints *kapi.Endpoints) error {
+	endpoints *kapi.Endpoints, service *kapi.Service) error {
 
 	glog.V(4).Infof("Processing %d Endpoints for Name: %v (%v)",
 		len(endpoints.Subsets), endpoints.Name, eventType)

--- a/plugins/router/template/plugin.go
+++ b/plugins/router/template/plugin.go
@@ -11,6 +11,7 @@ import (
 	ktypes "k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/kubernetes/pkg/util/unidling"
 
 	routeapi "github.com/openshift/origin/pkg/route/api"
 )
@@ -110,7 +111,7 @@ func NewTemplatePlugin(cfg TemplatePluginConfig) (*TemplatePlugin, error) {
 }
 
 // HandleEndpoints processes watch events on the Endpoints resource.
-func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
+func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints, service *kapi.Service) error {
 	key := endpointsKey(endpoints)
 
 	glog.V(4).Infof("Processing %d Endpoints for Name: %v (%v)", len(endpoints.Subsets), endpoints.Name, eventType)
@@ -126,7 +127,7 @@ func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *k
 	switch eventType {
 	case watch.Added, watch.Modified:
 		glog.V(4).Infof("Modifying endpoints for %s", key)
-		routerEndpoints := createRouterEndpoints(endpoints, !p.IncludeUDP)
+		routerEndpoints := createRouterEndpoints(endpoints, !p.IncludeUDP, service)
 		key := endpointsKey(endpoints)
 		commit := p.Router.AddEndpoints(key, routerEndpoints)
 		if commit {
@@ -191,11 +192,41 @@ func peerEndpointsKey(namespacedName ktypes.NamespacedName) string {
 }
 
 // createRouterEndpoints creates openshift router endpoints based on k8s endpoints
-func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool) []Endpoint {
+func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool, service *kapi.Service) []Endpoint {
+	// check if this service is currently idled
+	subsets := endpoints.Subsets
+	if _, ok := endpoints.Annotations[unidling.IdledAtAnnotation]; ok && len(endpoints.Subsets) == 0 {
+		if service == nil {
+			// TODO: actually return an error
+			glog.Errorf("no idled service found corresponding to idled endpoints %v/%v", endpoints.Namespace, endpoints.Name)
+			return []Endpoint{}
+		}
+
+		svcSubset := kapi.EndpointSubset{
+			// TODO: is just ClusterIP ok here?
+			Addresses: []kapi.EndpointAddress{
+				{
+					IP: service.Spec.ClusterIP,
+				},
+			},
+		}
+
+		for _, port := range service.Spec.Ports {
+			endptPort := kapi.EndpointPort{
+				Name: port.Name,
+				Port: port.Port,
+				Protocol: port.Protocol,
+			}
+			svcSubset.Ports = append(svcSubset.Ports, endptPort)
+		}
+
+		subsets = []kapi.EndpointSubset{svcSubset}
+	}
+
 	out := make([]Endpoint, 0, len(endpoints.Subsets)*4)
 
 	// TODO: review me for sanity
-	for _, s := range endpoints.Subsets {
+	for _, s := range subsets {
 		for _, p := range s.Ports {
 			if excludeUDP && p.Protocol == kapi.ProtocolUDP {
 				continue


### PR DESCRIPTION
…pod ports.

This turns the ovs rules into a mutlilevel data structure with the
first level keyed on IP and the second port, where it points to a
structure with byte and packet counts seen for that IP:port.
